### PR TITLE
Potential fix for code scanning alert no. 5008: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/continuousdelivery.yml
+++ b/.github/workflows/continuousdelivery.yml
@@ -1,4 +1,6 @@
 name: Continuous Delivery
+permissions:
+  contents: read
 on:
     push:
         branches:


### PR DESCRIPTION
Potential fix for [https://github.com/gabrielgom3s/Dsiciplina-DevOps/security/code-scanning/5008](https://github.com/gabrielgom3s/Dsiciplina-DevOps/security/code-scanning/5008)

To fix the problem, add a `permissions` key to the workflow to explicitly set the GITHUB_TOKEN permissions to the minimal required for the workflow’s jobs. In this case, only reading repository contents (to check out code and upload/download artifacts) is needed, so set `permissions: contents: read` at the workflow level (just below the `name:` and `on:` keys, so it applies to all jobs unless explicitly overridden). No change in functionality will result. The edit should be made at the top of `.github/workflows/continuousdelivery.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
